### PR TITLE
fix: resolve existing React lifecycle lint errors

### DIFF
--- a/app/[lang]/playground/theme-customizer/components/theme-sections.tsx
+++ b/app/[lang]/playground/theme-customizer/components/theme-sections.tsx
@@ -4,7 +4,7 @@ import type { Theme } from '@univerjs/themes'
 import type { ReactNode } from 'react'
 import { Button, clsx, FormLayout, Input, Select, Textarea } from '@univerjs/design'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { ColorPickerPopover } from '@/components/color-picker-popover'
 
@@ -25,9 +25,11 @@ export function ThemeColorField(props: { label: string; value: string; onChange:
   const t = useTranslations()
   const [draftValue, setDraftValue] = useState(value)
 
-  useEffect(() => {
+  const [previousValue, setPreviousValue] = useState(value)
+  if (value !== previousValue) {
+    setPreviousValue(value)
     setDraftValue(value)
-  }, [value])
+  }
 
   const error =
     draftValue.trim().length > 0 && !normalizeHexColor(draftValue) ? t('theme-customizer.invalid-hex') : undefined

--- a/app/[lang]/tools/theme-customizer/real-univer-preview.tsx
+++ b/app/[lang]/tools/theme-customizer/real-univer-preview.tsx
@@ -143,7 +143,9 @@ export function RealUniverPreview({
   const latestConfigRef = useRef({ darkMode, theme })
   const univerRef = useRef<Univer | null>(null)
 
-  latestConfigRef.current = { darkMode, theme }
+  useEffect(() => {
+    latestConfigRef.current = { darkMode, theme }
+  }, [darkMode, theme])
 
   useEffect(() => {
     if (!containerRef.current) return undefined

--- a/components/animate-ui/text/sliding-number.tsx
+++ b/components/animate-ui/text/sliding-number.tsx
@@ -3,7 +3,7 @@
 import type { MotionValue, SpringOptions, UseInViewOptions } from 'motion/react'
 import type { ComponentProps } from 'react'
 import { motion, useInView, useSpring, useTransform } from 'motion/react'
-import { useCallback, useEffect, useImperativeHandle, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import useMeasure from 'react-use-measure'
 import { clsx } from '@/lib/clsx'
 
@@ -120,12 +120,16 @@ function SlidingNumber({
   })
   const isInView = !inView || inViewResult
 
-  const prevNumberRef = useRef<number>(0)
-
   const effectiveNumber = useMemo(
     () => (!isInView ? 0 : Math.abs(Number(number))),
     [number, isInView],
   )
+  const [lastNumber, setLastNumber] = useState(0)
+  const [previousNumber, setPreviousNumber] = useState(0)
+  if (lastNumber !== effectiveNumber) {
+    setPreviousNumber(lastNumber)
+    setLastNumber(effectiveNumber)
+  }
 
   const formatNumber = useCallback(
     (num: number) =>
@@ -138,7 +142,7 @@ function SlidingNumber({
   const newIntStr
     = padStart && newIntStrRaw?.length === 1 ? `0${newIntStrRaw}` : newIntStrRaw
 
-  const prevFormatted = formatNumber(prevNumberRef.current)
+  const prevFormatted = formatNumber(previousNumber)
   const [prevIntStrRaw = '', prevDecStrRaw = ''] = prevFormatted.split('.')
   const prevIntStr
     = padStart && prevIntStrRaw.length === 1
@@ -157,10 +161,6 @@ function SlidingNumber({
       ? prevDecStrRaw.slice(0, newDecStrRaw.length)
       : prevDecStrRaw.padEnd(newDecStrRaw.length, '0')
   }, [prevDecStrRaw, newDecStrRaw])
-
-  useEffect(() => {
-    if (isInView) prevNumberRef.current = effectiveNumber
-  }, [effectiveNumber, isInView])
 
   const intDigitCount = newIntStr?.length ?? 0
   const intPlaces = useMemo(

--- a/components/magicui/terminal.tsx
+++ b/components/magicui/terminal.tsx
@@ -1,9 +1,8 @@
 'use client'
 
 import type { MotionProps } from 'motion/react'
-import type { ElementType, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { motion } from 'motion/react'
-import { useEffect, useRef, useState } from 'react'
 import { clsx } from '@/lib/clsx'
 
 interface IAnimatedSpanProps extends MotionProps {
@@ -28,70 +27,6 @@ export function AnimatedSpan({
     >
       {children}
     </motion.div>
-  )
-}
-
-interface TypingAnimationProps extends MotionProps {
-  children: string
-  className?: string
-  duration?: number
-  delay?: number
-  as?: ElementType
-}
-
-export function TypingAnimation({
-  children,
-  className,
-  duration = 60,
-  delay = 0,
-  as: Component = 'span',
-  ...props
-}: TypingAnimationProps) {
-  if (typeof children !== 'string') {
-    throw new TypeError('TypingAnimation: children must be a string. Received:')
-  }
-
-  const MotionComponent = motion.create(Component, {
-    forwardMotionProps: true,
-  })
-
-  const [displayedText, setDisplayedText] = useState<string>('')
-  const [started, setStarted] = useState(false)
-  const elementRef = useRef<HTMLElement | null>(null)
-
-  useEffect(() => {
-    const startTimeout = setTimeout(() => {
-      setStarted(true)
-    }, delay)
-    return () => clearTimeout(startTimeout)
-  }, [delay])
-
-  useEffect(() => {
-    if (!started) return
-
-    let i = 0
-    const typingEffect = setInterval(() => {
-      if (i < children.length) {
-        setDisplayedText(children.substring(0, i + 1))
-        i++
-      } else {
-        clearInterval(typingEffect)
-      }
-    }, duration)
-
-    return () => {
-      clearInterval(typingEffect)
-    }
-  }, [children, duration, started])
-
-  return (
-    <MotionComponent
-      ref={elementRef}
-      className={clsx('font-mono text-sm tracking-tight', className)}
-      {...props}
-    >
-      {displayedText}
-    </MotionComponent>
   )
 }
 

--- a/components/ui-layouts/animated-beam.tsx
+++ b/components/ui-layouts/animated-beam.tsx
@@ -34,7 +34,7 @@ export const AnimatedBeam: React.FC<AnimatedBeamProps> = ({
   toRef,
   curvature = 0,
   reverse = false, // Include the reverse prop
-  duration = Math.random() * 3 + 4,
+  duration = 5,
   delay = 0,
   pathColor = 'gray',
   pathWidth = 2,

--- a/components/ui/shadcn-io/color-picker/index.tsx
+++ b/components/ui/shadcn-io/color-picker/index.tsx
@@ -43,26 +43,25 @@ export type ColorPickerProps = HTMLAttributes<HTMLDivElement> & {
 }
 
 export function ColorPicker({ value, defaultValue = '#000000', onChange, className, ...props }: ColorPickerProps) {
-  const selectedColor = Color(value)
-  const defaultColor = Color(defaultValue)
+  const selectedColor = Color(value ?? defaultValue)
 
-  const [hue, setHue] = useState(selectedColor.hue() || defaultColor.hue() || 0)
-  const [saturation, setSaturation] = useState(selectedColor.saturationl() || defaultColor.saturationl() || 100)
-  const [lightness, setLightness] = useState(selectedColor.lightness() || defaultColor.lightness() || 50)
-  const [alpha, setAlpha] = useState(selectedColor.alpha() * 100 || defaultColor.alpha() * 100)
+  const [hue, setHue] = useState(selectedColor.hue())
+  const [saturation, setSaturation] = useState(selectedColor.saturationl())
+  const [lightness, setLightness] = useState(selectedColor.lightness())
+  const [alpha, setAlpha] = useState(selectedColor.alpha() * 100)
   const [mode, setMode] = useState('hex')
 
-  // Update color when controlled value changes
-  useEffect(() => {
-    if (value) {
-      const color = Color.rgb(value).rgb().object()
-
-      setHue(color.r)
-      setSaturation(color.g)
-      setLightness(color.b)
-      setAlpha(color.a)
+  const controlledColor = value == null ? undefined : selectedColor.hexa()
+  const [previousColor, setPreviousColor] = useState(controlledColor)
+  if (controlledColor !== previousColor) {
+    setPreviousColor(controlledColor)
+    if (controlledColor !== undefined) {
+      setHue(selectedColor.hue())
+      setSaturation(selectedColor.saturationl())
+      setLightness(selectedColor.lightness())
+      setAlpha(selectedColor.alpha() * 100)
     }
-  }, [value])
+  }
 
   // Notify parent of changes
   useEffect(() => {

--- a/showcase/docs/node-via-plugin/preview/main.tsx
+++ b/showcase/docs/node-via-plugin/preview/main.tsx
@@ -5,15 +5,12 @@ import { IUniverInstanceService, LocaleType, Univer, UniverInstanceType } from '
 import { UniverDocsPlugin } from '@univerjs/docs'
 import { UniverFormulaEnginePlugin } from '@univerjs/engine-formula'
 import { UniverRenderEnginePlugin } from '@univerjs/engine-render'
-import { useTheme } from 'next-themes'
-import { useEffect, useState } from 'react'
-import { Terminal, TypingAnimation } from '@/components/magicui/terminal'
+import { useEffect, useRef } from 'react'
+import { Terminal } from '@/components/magicui/terminal'
 import { DOCUMENT_DATA } from '../code/data'
 
 export default function Preview() {
-  const [snapshots, setSnapshots] = useState<string>('')
-
-  const { theme } = useTheme()
+  const outputRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
     const univer = new Univer({
@@ -37,17 +34,18 @@ export default function Preview() {
 
     const snapshots = units.map(unit => unit.getSnapshot())
 
-    setSnapshots(JSON.stringify(snapshots, null, 2))
+    // Render the actual headless SDK result into its dedicated output node.
+    if (outputRef.current) outputRef.current.textContent = JSON.stringify(snapshots, null, 2)
 
     return () => {
       univer.dispose()
     }
-  }, [theme])
+  }, [])
 
   return (
     <div className="h-full">
       <Terminal>
-        <TypingAnimation duration={0}>{snapshots}</TypingAnimation>
+        <span ref={outputRef} />
       </Terminal>
     </div>
   )


### PR DESCRIPTION
## Summary

- Extract the existing React lint fixes from Showcase PR #124 into a small prerequisite PR.
- Synchronize color drafts during guarded prop changes, preserve zero-valued HSL/alpha channels, and update preview configuration refs after commit.
- Track previous animated numbers in state and use a deterministic beam duration.
- Render the headless Docs snapshot directly into its dedicated output node and remove its now-unused typing animation.

## Validation

- Repository lint: zero errors in the tested Showcase integration branch.
- Showcase typecheck and source/CSS export checks passed in the integration branch.
- The same fixes passed GitHub static checks in #124 on 03ac1b3; this standalone base branch must pass its own CI.
- No lint rules or assertions disabled. No SDK dependencies, CI workflow changes, submodules or generated evidence files included.

## Scope

Please review and merge this prerequisite before #124, then synchronize #124 with dev. This PR does not merge or deploy automatically. The repository has no PR template under .github.