### PR TITLE
docs(server): update transport attachment and HTTP timing examples

### DIFF
--- a/content/server/collaboration/middleware-and-events.es-ES.mdx
+++ b/content/server/collaboration/middleware-and-events.es-ES.mdx
@@ -46,28 +46,41 @@ El Middleware HTTP de Transport puede terminar la respuesta sin llamar a `next()
 
 ## Middleware de Transport
 
-Transport separa las cadenas de solicitudes HTTP ordinarias y actualizaciones WebSocket:
+`transport.use()` registra Middleware HTTP ordinario, que se ejecuta en orden de registro. Llama a `await next()` para continuar el procesamiento o finaliza la respuesta directamente. `transport.useUpgrade()` gestiona los protocolos de enlace WebSocket.
+
+Por ejemplo, registra la duración HTTP, autentica y establece un `userID` de confianza y, después, registra el Collaboration Endpoint:
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` solo participa en HTTP ordinario: identidad, registro de solicitudes, trazas, CORS y `customData` local. `transport.useUpgrade()` solo participa en el protocolo de enlace WebSocket y puede rechazarlo antes de conectar.
+La aplicación proporciona `recordHttpDuration` y `authenticate`. Endpoint utiliza el `userID` establecido por los Middleware anteriores. El Middleware de observación se registra antes de la autenticación, por lo que también se registran los rechazos.
+
+`context.route?.path` es la plantilla completa de la ruta coincidente, disponible cuando la ejecución llega al Endpoint. Usa el evento `finish` de la respuesta para medir el tiempo hasta su finalización; los rechazos anteriores a la resolución de la ruta y las rutas desconocidas se registran como `unmatched`.
 
 ## Middleware de Endpoint
 

--- a/content/server/collaboration/middleware-and-events.fr-FR.mdx
+++ b/content/server/collaboration/middleware-and-events.fr-FR.mdx
@@ -46,28 +46,41 @@ Un Middleware HTTP Transport peut terminer la réponse sans `next()`. Les Middle
 
 ## Middleware Transport
 
-Le Transport sépare les chaînes des requêtes HTTP ordinaires et des mises à niveau WebSocket :
+`transport.use()` enregistre les Middleware HTTP ordinaires, exécutés dans l’ordre d’enregistrement. Appelez `await next()` pour poursuivre le traitement, ou terminez directement la réponse. `transport.useUpgrade()` traite les négociations WebSocket.
+
+Par exemple, mesurez la durée HTTP, authentifiez la requête et définissez un `userID` fiable, puis enregistrez le Collaboration Endpoint :
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` intervient uniquement pour HTTP ordinaire : identité, logs de requête, traçage, CORS et `customData` local à la requête. `transport.useUpgrade()` intervient uniquement dans la négociation WebSocket et peut la refuser avant connexion.
+L’application fournit `recordHttpDuration` et `authenticate`. L’Endpoint utilise le `userID` défini par les Middleware précédents. Le Middleware d’observation précède l’authentification afin d’enregistrer également les refus.
+
+`context.route?.path` est le modèle complet de la route correspondante, disponible lorsque l’exécution atteint l’Endpoint. Utilisez l’événement `finish` de la réponse pour mesurer le temps jusqu’à sa fin ; les refus avant la résolution de la route et les chemins inconnus sont enregistrés comme `unmatched`.
 
 ## Middleware Endpoint
 

--- a/content/server/collaboration/middleware-and-events.ja-JP.mdx
+++ b/content/server/collaboration/middleware-and-events.ja-JP.mdx
@@ -46,28 +46,41 @@ Transport HTTP Middleware は `next()` を呼ばずに HTTP レスポンスを�
 
 ## Transport Middleware
 
-Transport は通常の HTTP リクエストと WebSocket アップグレードに別々の Middleware チェーンを持ちます。
+`transport.use()` は通常の HTTP Middleware を登録し、登録順に実行します。`await next()` で後続の処理に進むか、レスポンスを直接終了できます。`transport.useUpgrade()` は WebSocket ハンドシェイクを処理します。
+
+次の例では、HTTP の所要時間を記録し、認証して信頼できる `userID` を設定した後、Collaboration Endpoint を登録します。
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` は通常の HTTP リクエストのみが対象で、本人確認、リクエストログ、追跡、CORS、リクエスト内 `customData` に適しています。`transport.useUpgrade()` は WebSocket ハンドシェイクのみが対象で、接続前に拒否できます。
+`recordHttpDuration` と `authenticate` はアプリケーションが提供します。Endpoint は前段の Middleware が設定した `userID` を使用します。観測用 Middleware を認証より前に登録するため、認証による拒否も記録されます。
+
+`context.route?.path` は一致した完全なルートテンプレートで、処理が Endpoint に到達した時点で利用できます。response の `finish` イベントでレスポンス完了までの時間を計測します。ルートの照合前に拒否されたリクエストや未知のパスは `unmatched` として記録されます。
 
 ## Endpoint Middleware
 

--- a/content/server/collaboration/middleware-and-events.ko-KR.mdx
+++ b/content/server/collaboration/middleware-and-events.ko-KR.mdx
@@ -46,28 +46,41 @@ Transport HTTP Middleware는 `next()` 호출 없이 HTTP 응답을 종료할 수
 
 ## Transport Middleware
 
-Transport에는 일반 HTTP 요청과 WebSocket 업그레이드용 독립 Middleware 체인이 있습니다.
+`transport.use()`는 일반 HTTP Middleware를 등록하며 등록 순서대로 실행합니다. `await next()`를 호출해 다음 처리를 진행하거나 응답을 직접 종료할 수 있습니다. `transport.useUpgrade()`는 WebSocket 핸드셰이크를 처리합니다.
+
+다음 예제는 HTTP 소요 시간을 기록하고, 인증 후 신뢰할 수 있는 `userID`를 설정한 다음 Collaboration Endpoint를 등록합니다.
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()`는 일반 HTTP 요청에만 참여하며 신원 확인, 요청 로깅, 추적, CORS, 요청 내부 `customData`에 적합합니다. `transport.useUpgrade()`는 WebSocket 핸드셰이크에만 참여하며 연결 전에 거부할 수 있습니다.
+`recordHttpDuration`과 `authenticate`는 애플리케이션에서 제공합니다. Endpoint는 앞선 Middleware가 설정한 `userID`를 사용합니다. 관측 Middleware를 인증보다 먼저 등록하므로 인증 거부도 기록됩니다.
+
+`context.route?.path`는 일치한 전체 경로 템플릿이며 처리가 Endpoint에 도달하면 사용할 수 있습니다. response의 `finish` 이벤트로 응답 완료까지의 시간을 측정합니다. 경로 매칭 전의 거부와 알 수 없는 경로는 `unmatched`로 기록됩니다.
 
 ## Endpoint Middleware
 

--- a/content/server/collaboration/middleware-and-events.mdx
+++ b/content/server/collaboration/middleware-and-events.mdx
@@ -52,30 +52,47 @@ Middleware should reject with an explicit error rather than silently skipping `n
 
 ## Transport Middleware
 
-The Transport has separate Middleware chains for ordinary HTTP requests and WebSocket upgrades:
+`transport.use()` registers ordinary HTTP Middleware, executed in registration order. Call
+`await next()` to continue processing, or end the response directly. `transport.useUpgrade()`
+handles WebSocket handshakes.
+
+For example, record HTTP duration, authenticate and set a trusted `userID`, then register the
+Collaboration Endpoint:
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` participates only in ordinary HTTP requests. It is suitable for identity,
-request logging, tracing, CORS, and request-local `customData`. `transport.useUpgrade()` participates
-only in the WebSocket handshake and can reject it before connection.
+The application supplies `recordHttpDuration` and `authenticate`. Endpoint uses the `userID` set
+by earlier Middleware. Observation comes before authentication, so rejections are also recorded.
+
+`context.route?.path` is the full matched route template, available when execution reaches the
+Endpoint. Use response `finish` to measure response completion; rejections before routing and
+unknown paths are recorded as `unmatched`.
 
 ## Endpoint Middleware
 

--- a/content/server/collaboration/middleware-and-events.ru-RU.mdx
+++ b/content/server/collaboration/middleware-and-events.ru-RU.mdx
@@ -46,28 +46,41 @@ HTTP Middleware Transport может закончить ответ без `next(
 
 ## Middleware Transport
 
-Transport разделяет цепочки обычных HTTP-запросов и обновлений до WebSocket:
+`transport.use()` регистрирует Middleware для обычных HTTP-запросов; они выполняются в порядке регистрации. Вызовите `await next()`, чтобы продолжить обработку, или завершите ответ напрямую. `transport.useUpgrade()` обрабатывает рукопожатия WebSocket.
+
+Например, сначала измерьте длительность HTTP-запроса, затем выполните аутентификацию и задайте доверенный `userID`, после чего зарегистрируйте Collaboration Endpoint:
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` участвует только в обычном HTTP: идентификация, логи запросов, трассировка, CORS и локальный `customData`. `transport.useUpgrade()` участвует только в рукопожатии WebSocket и может отклонить его до подключения.
+Приложение предоставляет `recordHttpDuration` и `authenticate`. Endpoint использует `userID`, заданный предыдущими Middleware. Middleware наблюдения регистрируется до аутентификации, поэтому отказы также учитываются.
+
+`context.route?.path` — полный шаблон совпавшего маршрута, доступный, когда выполнение достигает Endpoint. Событие `finish` ответа позволяет измерить время до его завершения; отказы до сопоставления маршрута и неизвестные пути записываются как `unmatched`.
 
 ## Middleware Endpoint
 

--- a/content/server/collaboration/middleware-and-events.zh-CN.mdx
+++ b/content/server/collaboration/middleware-and-events.zh-CN.mdx
@@ -51,29 +51,44 @@ Middleware 若要拒绝操作，应抛出明确错误，而不是静默跳过 `n
 
 ## Transport Middleware
 
-Transport 位于网络入口，提供普通 HTTP 与 WebSocket Upgrade 两条 Middleware 链：
+`transport.use()` 注册普通 HTTP Middleware，按注册顺序执行。调用 `await next()`
+进入后续处理，也可以直接结束响应。`transport.useUpgrade()` 则用于 WebSocket 握手。
+
+例如，先统计 HTTP 耗时，再认证并设置可信 `userID`，最后注册 Collaboration Endpoint：
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` 只参与普通 HTTP request。它适合身份解析、请求日志、trace、CORS 或建立请求级
-`customData`。`transport.useUpgrade()` 只参与 WebSocket handshake，适合握手前检查。
+`recordHttpDuration` 和 `authenticate` 由应用提供。Endpoint 使用前序 Middleware 设置的
+`userID` 处理请求；观测 Middleware 注册在认证之前，因此认证拒绝也会被记录。
+
+`context.route?.path` 是匹配后的完整路由模板，在执行到 Endpoint 时才可用。
+通过 response `finish` 统计响应完成的耗时；路由匹配前的拒绝和未知路径记为 `unmatched`。
 
 ## Endpoint Middleware
 

--- a/content/server/collaboration/middleware-and-events.zh-TW.mdx
+++ b/content/server/collaboration/middleware-and-events.zh-TW.mdx
@@ -46,28 +46,41 @@ Transport HTTP Middleware 可不呼叫 `next()` 而直接結束 HTTP 回應。Se
 
 ## Transport Middleware
 
-Transport 為一般 HTTP 請求和 WebSocket 升級提供獨立的 Middleware 鏈：
+`transport.use()` 註冊一般 HTTP Middleware，依註冊順序執行。呼叫 `await next()` 繼續處理，或直接結束回應。`transport.useUpgrade()` 則處理 WebSocket 握手。
+
+例如，先記錄 HTTP 耗時，再驗證身分並設定可信的 `userID`，最後註冊 Collaboration Endpoint：
 
 ```ts
 transport.use(async (context, next) => {
-  context.customData.traceID = readTraceID(context.incomingMessage);
-  requestLogger.info("collaboration request", {
-    method: context.incomingMessage.method,
-    traceID: context.customData.traceID,
+  const start = performance.now();
+  context.response.once("finish", () => {
+    recordHttpDuration({
+      method: context.incomingMessage.method,
+      route: context.route?.path ?? "unmatched",
+      status: context.response.statusCode,
+      durationMs: performance.now() - start,
+    });
   });
   await next();
 });
 
-transport.useUpgrade(async (context, next) => {
-  if (!isAllowedOrigin(context.incomingMessage.headers.origin)) {
-    context.reject(403, "Origin rejected");
+transport.use(async (context, next) => {
+  const user = await authenticate(context.incomingMessage);
+  if (!user) {
+    context.response.statusCode = 401;
+    context.response.end("Authentication required");
     return;
   }
+  context.userID = user.userId;
   await next();
 });
+
+transport.register(collaborationEndpoint);
 ```
 
-`transport.use()` 只參與一般 HTTP 請求，適用於身分、請求日誌、追蹤、CORS 及請求內 `customData`。`transport.useUpgrade()` 只參與 WebSocket 握手，可在連線前拒絕。
+`recordHttpDuration` 和 `authenticate` 由應用程式提供。Endpoint 使用前序 Middleware 設定的 `userID`。觀測 Middleware 註冊在驗證之前，因此也會記錄驗證拒絕。
+
+`context.route?.path` 是匹配後的完整路由範本，在執行到 Endpoint 時才可用。透過 response 的 `finish` 事件量測回應完成的耗時；路由匹配前的拒絕與未知路徑記為 `unmatched`。
 
 ## Endpoint Middleware
 

--- a/content/server/collaboration/modules.es-ES.mdx
+++ b/content/server/collaboration/modules.es-ES.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.fr-FR.mdx
+++ b/content/server/collaboration/modules.fr-FR.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.ja-JP.mdx
+++ b/content/server/collaboration/modules.ja-JP.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.ko-KR.mdx
+++ b/content/server/collaboration/modules.ko-KR.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.mdx
+++ b/content/server/collaboration/modules.mdx
@@ -159,12 +159,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.ru-RU.mdx
+++ b/content/server/collaboration/modules.ru-RU.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.zh-CN.mdx
+++ b/content/server/collaboration/modules.zh-CN.mdx
@@ -149,12 +149,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/modules.zh-TW.mdx
+++ b/content/server/collaboration/modules.zh-TW.mdx
@@ -140,12 +140,8 @@ transport.use(async (context, next) => {
 });
 transport.register(endpoint);
 
-const server = createServer((request, response) => {
-  transport.handleRequest(request, response);
-});
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+const server = createServer();
+transport.attach(server);
 server.listen(3010);
 ```
 

--- a/content/server/collaboration/quick-start.es-ES.mdx
+++ b/content/server/collaboration/quick-start.es-ES.mdx
@@ -45,7 +45,7 @@ La sincronización indica que los navegadores cargaron una Unit por HTTP, abrier
 
 ## Camino dos: integrarlo en tu aplicación
 
-El código siguiente procede de los dos puntos de entrada oficiales, sin el texto de estado de la página. El código completo ejecutable está aquí:
+El código siguiente muestra la composición mínima de Server y Web. El inicio rápido oficial proporciona la estructura completa de la aplicación:
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ El `demo-user` fijo muestra cómo la identidad de confianza pasa de Transport a 
 
 ### 3. Montar autorización y puntos de entrada HTTP y WebSocket
 
-El cliente Collaboration actual consulta un protocolo de autorización. El ejemplo devuelve siempre `allowed: true` y reenvía solicitudes HTTP de `/universer-api` y actualizaciones WebSocket al Transport:
+El cliente Collaboration actual consulta un protocolo de autorización. El inicio rápido devuelve siempre `allowed: true` para esa ruta y conecta Transport al servidor HTTP de la aplicación:
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.fr-FR.mdx
+++ b/content/server/collaboration/quick-start.fr-FR.mdx
@@ -45,7 +45,7 @@ La synchronisation entre navigateurs signifie qu’ils ont chargé une Unit par 
 
 ## Deuxième parcours : intégrer dans votre application
 
-Le code suivant provient des deux points d’entrée officiels, sans les textes d’état propres à la page. Le code exécutable complet est disponible ici :
+Le code suivant montre la composition minimale du Server et du Web. Le démarrage rapide officiel fournit la structure complète de l’application :
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ Le `demo-user` fixe illustre la transmission de l’identité de confiance depui
 
 ### 3. Monter les points d’entrée d’autorisation, HTTP et WebSocket
 
-Le client Collaboration actuel interroge un protocole d’autorisation. Le démarrage rapide renvoie toujours `allowed: true`, puis transmet les requêtes HTTP `/universer-api` et les mises à niveau WebSocket au Transport :
+Le client Collaboration actuel interroge un protocole d’autorisation. Le démarrage rapide renvoie toujours `allowed: true` pour cette route et rattache le Transport au serveur HTTP de l’application :
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.ja-JP.mdx
+++ b/content/server/collaboration/quick-start.ja-JP.mdx
@@ -45,7 +45,7 @@ Univer Collaboration Client
 
 ## 手順 2：アプリケーションに組み込む
 
-以下は公式クイックスタートの 2 つのエントリーポイントから、ページ用の状態表示だけを除いたコードです。実行可能な完全版はこちらです。
+以下は Server と Web の最小構成です。アプリケーション全体の構成は公式クイックスタートを参照してください。
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ await service.createUnitFromData(
 
 ### 3. 認可、HTTP、WebSocket の入口を配置する
 
-現在の Collaboration Client は認可プロトコルを問い合わせます。サンプルは常に `allowed: true` を返し、`/universer-api` の HTTP リクエストと WebSocket アップグレードを Transport に渡します。
+現在の Collaboration Client は認可プロトコルを問い合わせます。クイックスタートはこのルートで常に `allowed: true` を返し、Transport をアプリケーションの HTTP サーバーに接続します。
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.ko-KR.mdx
+++ b/content/server/collaboration/quick-start.ko-KR.mdx
@@ -45,7 +45,7 @@ Univer Collaboration Client
 
 ## 경로 2: 애플리케이션에 통합
 
-다음 코드는 공식 빠른 시작의 두 진입점에서 페이지 상태 표시 텍스트만 제거한 것입니다. 전체 실행 소스는 다음에서 확인할 수 있습니다.
+다음 코드는 Server와 Web의 최소 구성을 보여 줍니다. 전체 애플리케이션 구조는 공식 빠른 시작을 참고하세요.
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ await service.createUnitFromData(
 
 ### 3. 권한 부여, HTTP, WebSocket 진입점 연결
 
-현재 Collaboration Client는 권한 부여 프로토콜을 조회합니다. 빠른 시작은 항상 `allowed: true`를 반환하고 `/universer-api` HTTP 요청과 WebSocket 업그레이드를 Transport에 전달합니다.
+현재 Collaboration Client는 권한 부여 프로토콜을 조회합니다. 빠른 시작은 해당 경로에서 항상 `allowed: true`를 반환하고 Transport를 애플리케이션의 HTTP 서버에 연결합니다.
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.mdx
+++ b/content/server/collaboration/quick-start.mdx
@@ -51,8 +51,8 @@ new revision, saved it through the Adapter, and the Endpoint broadcast it to oth
 
 ## Path two: move it into your application
 
-The following code comes from the two official Quick Start entry points, with page-only status text
-removed. The complete runnable source is available here:
+The following code shows the minimal Server and Web assembly. The official Quick Start provides
+the complete application structure:
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -150,7 +150,7 @@ Service. A production application validates its own cookie, bearer token, or ses
 ### 3. Mount authorization, HTTP, and WebSocket entry points
 
 The current Collaboration Client queries an authorization protocol. Quick Start always returns
-`allowed: true`, then forwards `/universer-api` HTTP requests and WebSocket upgrades to Transport:
+`allowed: true` for that route and attaches Transport to the application's HTTP server:
 
 ```ts
 const app = express();
@@ -169,16 +169,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.ru-RU.mdx
+++ b/content/server/collaboration/quick-start.ru-RU.mdx
@@ -45,7 +45,7 @@ Univer Collaboration Client
 
 ## Второй путь: перенос в приложение
 
-Ниже код из двух официальных точек входа без текстов состояния страницы. Полный исполняемый исходный код:
+Ниже показана минимальная сборка Server и Web. Полная структура приложения доступна в официальном примере быстрого старта:
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ await service.createUnitFromData(
 
 ### 3. Подключение авторизации, HTTP и WebSocket
 
-Текущий клиент Collaboration запрашивает протокол авторизации. Пример всегда возвращает `allowed: true`, затем передаёт HTTP-запросы `/universer-api` и WebSocket upgrade в Transport:
+Текущий клиент Collaboration запрашивает протокол авторизации. Пример всегда возвращает `allowed: true` для этого маршрута и подключает Transport к HTTP-серверу приложения:
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.zh-CN.mdx
+++ b/content/server/collaboration/quick-start.zh-CN.mdx
@@ -50,7 +50,7 @@ Endpoint 广播给其他成员。
 
 ## 路径二：迁入自己的应用
 
-下面的代码来自官方 Quick Start 的两个入口文件，并去掉了只用于页面提示的部分。完整可运行版本见：
+下面展示最小的 Server 与 Web 组装。完整应用结构可参考官方 Quick Start：
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -144,8 +144,8 @@ await service.createUnitFromData(
 
 ### 3. 挂载授权、HTTP 与 WebSocket 入口
 
-当前 Collaboration Client 会查询授权协议。Quick Start 返回固定 `allowed: true`，然后把
-`/universer-api` HTTP 请求与 WebSocket upgrade 交给 Transport：
+当前 Collaboration Client 会查询授权协议。Quick Start 为该接口返回固定 `allowed: true`，
+并将 Transport 挂载到应用的 HTTP Server：
 
 ```ts
 const app = express();
@@ -164,16 +164,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 

--- a/content/server/collaboration/quick-start.zh-TW.mdx
+++ b/content/server/collaboration/quick-start.zh-TW.mdx
@@ -45,7 +45,7 @@ Univer Collaboration Client
 
 ## 路徑二：整合到應用程式
 
-以下程式碼取自官方快速開始的兩個入口，只移除了頁面狀態文字。完整可執行原始碼：
+以下展示 Server 與 Web 的最小組合。官方快速開始提供完整的應用程式結構：
 
 - [server/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/server/main.ts)
 - [web/main.ts](https://github.com/dream-num/univer-collaboration-examples/blob/main/examples/quick-start/web/main.ts)
@@ -133,7 +133,7 @@ await service.createUnitFromData(
 
 ### 3. 掛載授權、HTTP 與 WebSocket 入口
 
-目前 Collaboration Client 會查詢授權協定。快速開始一律回傳 `allowed: true`，再將 `/universer-api` 的 HTTP 請求與 WebSocket 升級轉送給 Transport：
+目前 Collaboration Client 會查詢授權協定。快速開始為該路由回傳固定的 `allowed: true`，並將 Transport 掛載到應用程式的 HTTP Server：
 
 ```ts
 const app = express();
@@ -152,16 +152,10 @@ app.post("/universer-api/authz/-/object/-/batch_allowed", express.json(), (reque
   });
 });
 
-app.use("/universer-api", (request, response) => {
-  request.url = request.originalUrl;
-  transport.handleRequest(request, response);
-});
 app.use(express.static("dist/web"));
 
 const server = createServer(app);
-server.on("upgrade", (request, socket, head) => {
-  transport.handleUpgrade(request, socket, head);
-});
+transport.attach(server);
 server.listen(3010, "127.0.0.1");
 ```
 


### PR DESCRIPTION
The Server SDK Quick Start and module assembly still wire HTTP requests and WebSocket upgrades manually. Use `transport.attach(server)` and add an HTTP duration example that records the matched `context.route?.path` when the response finishes, including authentication rejections as `unmatched`.

Update Quick Start, module boundaries, and Middleware and Events across all eight supported locales (24 MDX files). Preserve the new repository’s page structure and links. This carries forward https://github.com/dream-num/office.univer.ai/pull/12 into the Server SDK section.

## Release verification

`@univerjs-pro/collaboration-transport-node@1.0.0-rc.0` was published to the public npm registry on September 11, 2026 at 07:18:01 UTC (15:18:01 Asia/Shanghai), under the `rc` dist-tag. The published package exports `INodeTransport.attach(server)`, `NodeHttpTransportContext.route`, and `NodeRoute.path`, satisfying the API release conditions for these examples. The current `dev` requirements page already targets `1.0.0-rc.0`. The `latest` and `beta` dist-tags still point to `1.0.0-beta.2`; consumers need the documented RC version.

Route metadata originated in https://github.com/dream-num/univer-collaboration-sdk/pull/58 and attachment in https://github.com/dream-num/univer-collaboration-sdk/commit/7ca22fc6690eaae91c6f128ac04224d3ffb989d0.

## Validation

- Installed the frozen lockfile with Node.js 24.14.0 and pnpm 12.3.4.
- `git diff --check` passed.
- MDX compilation passed for all 24 changed pages.
- Confirmed the changed code examples match across all eight locales and all existing Markdown links are preserved.
- `pnpm lint` passed with warnings in unchanged files.
- `pnpm typecheck` failed in unchanged framework examples and Showcase code: missing Angular/Vue/Vite dependencies, TS5097 import-extension errors, and Board connector label type mismatches.
- `pnpm build` compiled successfully, but the full build did not complete. Static generation used 9 workers for 11,997 pages, encountered agent-documentation timeouts, and the build exited with SIGTERM after the user reported memory exhaustion. Do not treat this as a passing production build.
- GitHub CI failed at `Typecheck Showcase`: unchanged Board examples reference unsupported `lineBreak` and `text` fields (`connector-routing/code/data.ts:101` and `search-element-query/code/data.ts:48`).
